### PR TITLE
Export stl to full path

### DIFF
--- a/archaea/geometry/mesh.py
+++ b/archaea/geometry/mesh.py
@@ -2,6 +2,7 @@ from archaea.geometry.point3d import Point3d
 from archaea.geometry.face import Face
 from archaea.writer.to_stl import to_stl
 import numpy as np
+import os
 
 
 class Mesh:
@@ -36,4 +37,5 @@ class Mesh:
     def to_stl(self, path, file_name):
         vertices = np.array([vertex.to_a() for vertex in self.vertices])
         faces = np.array(self.polygons)
-        to_stl(faces, vertices, file_name)
+        file_path = os.path.join(path, file_name)
+        to_stl(faces, vertices, file_path)

--- a/archaea/writer/to_stl.py
+++ b/archaea/writer/to_stl.py
@@ -29,11 +29,11 @@ import stl
 # to_stl(faces, vertices, "test")
 
 
-def to_stl(faces, vertices, file_name):
+def to_stl(faces, vertices, file_path):
     geo = mesh.Mesh(np.zeros(faces.shape[0], dtype=mesh.Mesh.dtype))
     for i, f in enumerate(faces):
         for j in range(3):
             geo.vectors[i][j] = vertices[f[j], :]
 
     # Write the mesh to file
-    geo.save('%s.stl' % file_name, mode=stl.Mode.ASCII)
+    geo.save('%s.stl' % file_path, mode=stl.Mode.ASCII)


### PR DESCRIPTION
Previously mesh to stl export was exporting to same folder of the called script.